### PR TITLE
Add step to check given number of random sitemap URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Then the index sitemap should have child :childSitemapUrl
 Then /^the sitemap has ([0-9]+) children$/
 Then the multilanguage sitemap pass Google validation
 Then the sitemap URLs are alive
-Then /^([0-9]+) random sitemap URLs are live$/
+Then /^([0-9]+) random sitemap URLs are alive$/
 ```
 ##### HTMLContext
 ```

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Then the index sitemap should have child :childSitemapUrl
 Then /^the sitemap has ([0-9]+) children$/
 Then the multilanguage sitemap pass Google validation
 Then the sitemap URLs are alive
+Then /^([0-9]+) random sitemap URLs are live$/
 ```
 ##### HTMLContext
 ```

--- a/src/SitemapContext.php
+++ b/src/SitemapContext.php
@@ -259,4 +259,54 @@ class SitemapContext extends BaseContext
             );
         }
     }
+    
+        /**
+     * @param int $randomUrlsCount
+     *
+     * @throws \Exception
+     *
+     * @Then /^([0-9]+) random sitemap URLs are alive$/
+     */
+    public function randomSitemapUrlsAreAlive($randomUrlsCount)
+    {
+        $this->assertSitemapHasBeenRead();
+
+        $locNodes = $this->getXpathInspector()->query('//sm:urlset/sm:url/sm:loc');
+
+        if ($randomUrlsCount > $locNodes->length) {
+            throw new \Exception(
+                'Given number is too high. The sitemap contains of only ' . $locNodes->length . ' URLs.'
+            );
+        }
+
+        for ($i = 1; $i <= $randomUrlsCount; $i++) {
+
+            /** @var \DOMElement $locNode */
+            $locNode = $locNodes[rand(0, $randomUrlsCount - 1)];
+
+            try {
+                $this->visit($locNode->nodeValue);
+            } catch (RouteNotFoundException $e) {
+                throw new \Exception(
+                    sprintf(
+                        'Sitemap Url %s is not valid in Sitemap: %s. Exception: %s',
+                        $locNode->nodeValue,
+                        $this->sitemapXml->documentURI,
+                        $e->getMessage()
+                    )
+                );
+            }
+
+            Assert::assertEquals(
+                200,
+                $this->getStatusCode(),
+                sprintf(
+                    'Sitemap Url %s is not valid in Sitemap: %s. Response status code: %s',
+                    $locNode->nodeValue,
+                    $this->sitemapXml->documentURI,
+                    $this->getStatusCode()
+                )
+            );
+        }
+    }
 }

--- a/src/SitemapContext.php
+++ b/src/SitemapContext.php
@@ -260,7 +260,7 @@ class SitemapContext extends BaseContext
         }
     }
     
-        /**
+    /**
      * @param int $randomUrlsCount
      *
      * @throws \Exception


### PR DESCRIPTION
This PR adds a step to check only a given number of random sitemap URLs.

`@Then /^([0-9]+) random sitemap URLs are alive$/`.

Refs #5 

I must admit, it's not very DRY. Do you think we should try to reduce the amount of similar lines of code a bit more?