### PR TITLE
Asserting meta tags not empty

### DIFF
--- a/src/Context/MetaContext.php
+++ b/src/Context/MetaContext.php
@@ -50,7 +50,7 @@ class MetaContext extends BaseContext
     }
     
     /**
-     * @throws \Exception     
+     * @throws \Exception
      */
     private function assertCanonicalElementExists()
     {
@@ -146,7 +146,7 @@ class MetaContext extends BaseContext
     }
 
     /**
-     * @throws \Exception     
+     * @throws \Exception
      */
     private function assertTitleElementExists()
     {
@@ -202,7 +202,7 @@ class MetaContext extends BaseContext
     }
 
     /**
-     * @throws \Exception     
+     * @throws \Exception
      */
     private function assertPageMetaDescriptionElementExists()
     {

--- a/src/Context/MetaContext.php
+++ b/src/Context/MetaContext.php
@@ -14,15 +14,27 @@ class MetaContext extends BaseContext
      */
     public function thePageCanonicalShouldBe(string $expectedCanonicalUrl)
     {
-        Assert::assertNotNull(
-            $this->getCanonicalElement(),
-            'Canonical element does not exist'
-        );
+        $this->assertCanonicalElementExists();
 
         Assert::assertEquals(
             $this->toAbsoluteUrl($expectedCanonicalUrl),
             $this->getCanonicalElement()->getAttribute('href'),
             sprintf('Canonical url should be "%s"', $this->toAbsoluteUrl($expectedCanonicalUrl))
+        );
+    }
+    
+    /**
+     * @throws \Exception
+     *
+     * @Then the page canonical should not be empty
+     */
+    public function thePageCanonicalShouldNotBeEmpty()
+    {
+        $this->assertCanonicalElementExists();
+
+        Assert::assertNotEmpty(
+            trim($this->getCanonicalElement()->getAttribute('href')),
+            'Canonical url is empty'
         );
     }
 
@@ -32,8 +44,19 @@ class MetaContext extends BaseContext
     private function getCanonicalElement()
     {
         return $this->getSession()->getPage()->find(
-            'xpath',
-            '//head/link[@rel="canonical"]'
+                'xpath',
+                '//head/link[@rel="canonical"]'
+        );
+    }
+    
+    /**
+     * @throws \Exception     
+     */
+    private function assertCanonicalElementExists()
+    {
+        Assert::assertNotNull(
+            $this->getCanonicalElement(),
+            'Canonical element does not exist'
         );
     }
 
@@ -64,8 +87,8 @@ class MetaContext extends BaseContext
     private function getMetaRobotsElement()
     {
         return $this->getSession()->getPage()->find(
-            'xpath',
-            '//head/meta[@name="robots"]'
+                'xpath',
+                '//head/meta[@name="robots"]'
         );
     }
 
@@ -87,10 +110,7 @@ class MetaContext extends BaseContext
      */
     public function thePageTitleShouldBe(string $expectedTitle)
     {
-        Assert::assertNotNull(
-            $this->getTitleElement(),
-            'Title tag does not exist'
-        );
+        $this->assertTitleElementExists();
 
         Assert::assertEquals(
             $expectedTitle,
@@ -103,11 +123,37 @@ class MetaContext extends BaseContext
     }
 
     /**
+     * @throws \Exception
+     *
+     * @Then the page title should not be empty
+     */
+    public function thePageTitleShouldNotBeEmpty()
+    {
+        $this->assertTitleElementExists();
+
+        Assert::assertNotEmpty(
+            trim($this->getTitleElement()->getText()),
+            'Title tag is empty'
+        );
+    }
+
+    /**
      * @return NodeElement|null
      */
     private function getTitleElement()
     {
         return $this->getSession()->getPage()->find('css', 'title');
+    }
+
+    /**
+     * @throws \Exception     
+     */
+    private function assertTitleElementExists()
+    {
+        Assert::assertNotNull(
+            $this->getTitleElement(),
+            'Title tag does not exist'
+        );
     }
 
     /**
@@ -117,10 +163,7 @@ class MetaContext extends BaseContext
      */
     public function thePageMetaDescriptionShouldBe(string $expectedMetaDescription)
     {
-        Assert::assertNotNull(
-            $this->getMetaDescriptionElement(),
-            'Meta description does not exist'
-        );
+        $this->assertPageMetaDescriptionElementExists();
 
         Assert::assertEquals(
             $expectedMetaDescription,
@@ -133,13 +176,39 @@ class MetaContext extends BaseContext
     }
 
     /**
+     * @throws \Exception
+     *
+     * @Then the page meta description should not be empty
+     */
+    public function thePageMetaDescriptionNotBeEmpty()
+    {
+        $this->assertPageMetaDescriptionElementExists();
+
+        Assert::assertNotEmpty(
+            trim($this->getMetaDescriptionElement()->getAttribute('content')),
+            'Meta description is empty'
+        );
+    }
+
+    /**
      * @return NodeElement|null
      */
     private function getMetaDescriptionElement()
     {
         return $this->getSession()->getPage()->find(
-            'xpath',
-            '//head/meta[@name="description"]'
+                'xpath',
+                '//head/meta[@name="description"]'
+        );
+    }
+
+    /**
+     * @throws \Exception     
+     */
+    private function assertPageMetaDescriptionElementExists()
+    {
+        Assert::assertNotNull(
+            $this->getMetaDescriptionElement(),
+            'Meta description does not exist'
         );
     }
 

--- a/tests/features/meta.feature
+++ b/tests/features/meta.feature
@@ -5,12 +5,18 @@ Feature: Meta feature
     Given I am on "/meta/with-seo-meta.html"
     Then the page canonical should be "http://localhost:8080/meta/with-seo-meta.html"
 
+    When I am on "/meta/with-seo-meta.html"
+    Then the page canonical should not be empty
+
     When I am on "/meta/without-seo-meta.html"
     Then the page canonical should not exist
 
   Scenario: Testing page meta title
     Given I am on "/meta/with-seo-meta.html"
     Then the page title should be "Test title"
+
+    When I am on "/meta/with-seo-meta.html"
+    Then the page title should not be empty
 
     When I am on "/meta/with-empty-seo-meta.html"
     Then the page title should be ""
@@ -21,6 +27,9 @@ Feature: Meta feature
   Scenario: Testing page meta description
     Given I am on "/meta/with-seo-meta.html"
     Then the page meta description should be "Test description"
+
+    When I am on "/meta/with-seo-meta.html"
+    Then the page meta description should not be empty
 
     When I am on "/meta/with-empty-seo-meta.html"
     Then the page meta description should be ""
@@ -52,4 +61,4 @@ Feature: Meta feature
     Then the page meta robots should be noindex
 
     When I am on "/meta/robots/without-meta-robots.html"
-    Then the page meta robots should not be noindex
+    Then the page meta robots should not be noindex    


### PR DESCRIPTION
Sometimes is only needed to assert if tag's value is not empty.