### PR TITLE
Travis composer prefer matrix and PHP 7.3 builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,13 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  
+env:
+  matrix:
+    - COMPOSER_PREFER="--prefer-lowest --prefer-stable"        
+    - COMPOSER_PREFER="--prefer-stable"
+    - COMPOSER_PREFER=""
 
 before_script:
   - composer serve &> /dev/null &


### PR DESCRIPTION
* New Travis build fo PHP 7.3 version
* Travis matrix to build in default and 2 composer configurations:
 --prefer-stable: Prefer stable versions of dependencies.
 --prefer-lowest: Prefer lowest versions of dependencies. Useful for testing minimal versions of requirements, generally used with --prefer-stable
