### PR TITLE
Asserting HTML5 Doctype declaration

### DIFF
--- a/src/Context/HTMLContext.php
+++ b/src/Context/HTMLContext.php
@@ -7,6 +7,7 @@ use HtmlValidator\Exception\ServerException;
 use HtmlValidator\Exception\UnknownParserException;
 use HtmlValidator\Validator;
 use InvalidArgumentException;
+use Webmozart\Assert\Assert;
 
 class HTMLContext extends BaseContext
 {
@@ -62,5 +63,51 @@ class HTMLContext extends BaseContext
             [$this, 'thePageHtmlMarkupShouldBeValid'],
             'HTML markup should not be valid.'
         );
+    }
+
+    /**
+     * @Then the page HTML5 doctype declaration should be valid
+     */
+    public function thePageHtml5DoctypeDeclarationShouldBeValid(): void
+    {
+        $html5DoctypeMarkup = '<!doctype html>';
+
+        Assert::eq(
+            $html5DoctypeMarkup,
+            $this->pageDoctypeMarkup($html5DoctypeMarkup)
+        );
+    }
+
+    /**
+     * @Then the page HTML5 doctype declaration should not be valid
+     */
+    public function thePageHtml5DoctypeDeclarationShouldNotBeValid(): void
+    {
+        $this->assertInverse(
+            [$this, 'thePageHtml5DoctypeDeclarationShouldBeValid'],
+            'The page HTML5 doctype declaration should not be valid.'
+        );
+    }
+
+    private function pageDoctypeMarkup(string $htmlDoctypeMarkup): string
+    {
+        $pageContent = $this->removeCodeBeforePageDoctypeMarkup(
+            $this->getSession()->getPage()->getContent(),
+            $htmlDoctypeMarkup
+        );
+
+        $pageContentLines = explode(PHP_EOL, $pageContent);
+        return trim(strtolower($pageContentLines[0]));
+    }
+
+    private function removeCodeBeforePageDoctypeMarkup(string $pageContent, string $htmlDoctypeMarkup): string
+    {
+        $htmlDoctypeMarkupPositionInPageContent = stripos($pageContent, $htmlDoctypeMarkup);
+
+        if ($htmlDoctypeMarkupPositionInPageContent != false) {
+            $pageContent = substr($pageContent, $htmlDoctypeMarkupPositionInPageContent);
+        }
+
+        return $pageContent;
     }
 }

--- a/tests/features/html.feature
+++ b/tests/features/html.feature
@@ -7,3 +7,9 @@ Feature: HTML feature
 
     When I am on "/html/not-valid-html.html"
     Then the page HTML markup should not be valid
+ 
+    When I am on "/html/valid-html5-doctype-declaration.html"
+    Then the page HTML5 doctype declaration should be valid
+
+    When I am on "/html/not-valid-html5-doctype-declaration.html"
+    Then the page HTML5 doctype declaration should not be valid

--- a/tests/fixtures/web/html/not-valid-html5-doctype-declaration.html
+++ b/tests/fixtures/web/html/not-valid-html5-doctype-declaration.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Invalid HTML5 Doctype declaration</title>
+</head>
+<body>
+<p>Invalid HTML5 Doctype declaration</p>
+</body>
+</html>

--- a/tests/fixtures/web/html/valid-html5-doctype-declaration.html
+++ b/tests/fixtures/web/html/valid-html5-doctype-declaration.html
@@ -1,0 +1,19 @@
+
+
+<!-- nice comment -->
+
+
+<!-- nice comment 2 -->
+
+
+
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Valid HTML5 Doctype declaration</title>
+</head>
+<body>
+<p>Valid HTML5 Doctype declaration</p>
+</body>
+</html>


### PR DESCRIPTION
New scenario step
Then the page HTML5 doctype declaration should be valid

Sometimes It is only needed to check it instead of checking all page using
Then the page HTML markup should be valid